### PR TITLE
Changelog and Contributors: Use Release.tracMilestone() for the trac milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ for a specific release.
 See [docs/trac-contributors.sql](docs/trac-contributors.sql) for the SQL
 necessary to create the Trac report.
 
+#### tracMilestone()
+
+If using Trac, return a different milestone to be used in the queries to
+generate a changelog and list of contributors. Defaults to `newVersion`.
+
 ### Other Methods
 
 #### define( props )

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -17,6 +17,10 @@ Release.define({
 		return "";
 	},
 
+	tracMilestone: function() {
+		return Release.newVersion;
+	},
+
 	_generateCommitChangelog: function() {
 		var commits,
 			commitRef = "[%h](http://github.com/jquery/" + Release.project + "/commit/%H)",
@@ -61,7 +65,7 @@ Release.define({
 
 	_generateTracChangelog: function() {
 		console.log( "Adding Trac tickets..." );
-		return Release.trac( "/query?milestone=" + Release.newVersion + "&resolution=fixed" +
+		return Release.trac( "/query?milestone=" + Release.tracMilestone() + "&resolution=fixed" +
 			"&col=id&col=component&col=summary&order=component" ) + "\n";
 	},
 

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -44,7 +44,7 @@ Release.define({
 
 	_gatherTracContributors: function() {
 		var url = "/report/" + Release.contributorReportId +
-			"?V=" + Release.newVersion + "&max=-1";
+			"?V=" + Release.tracMilestone() + "&max=-1";
 
 		return Release.trac( url )
 			.split( /\r?\n/ )


### PR DESCRIPTION
This allows specific projects to configure the milestone used when querying trac.
