### PR TITLE
Repo: Update bower.json along with package.json when updating versions

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -3,6 +3,7 @@ var fs = require( "fs" );
 module.exports = function( Release ) {
 
 Release.define({
+	_jsonFiles: [ "package.json", "bower.json" ],
 	_cloneRepo: function() {
 		console.log( "Cloning " + Release.remote.cyan + "..." );
 		Release.git( "clone " + Release.remote + " " + Release.dir.repo, "Error cloning repo." );
@@ -68,15 +69,39 @@ Release.define({
 
 	checkRepoState: function() {},
 
-	readPackage: function() {
-		var package = fs.readFileSync( Release.dir.repo + "/package.json", "utf8" );
-		Release.packageIndentation = package.match( /\n([\t\s]+)/ )[ 1 ];
-		return JSON.parse( package );
+	_readJSON: function( fileName ) {
+		var json = fs.readFileSync( Release.dir.repo + "/" + fileName, "utf8" );
+		Release.packageIndentation = json.match( /\n([\t\s]+)/ )[ 1 ];
+		return JSON.parse( json );
 	},
 
-	writePackage: function( package ) {
-		fs.writeFileSync( Release.dir.repo + "/package.json",
-			JSON.stringify( package, null, Release.packageIndentation ) + "\n" );
+	_writeJSON: function( fileName, json ) {
+		fs.writeFileSync( Release.dir.repo + "/" + fileName,
+			JSON.stringify( json, null, Release.packageIndentation ) + "\n" );
+	},
+
+	readPackage: function() {
+		return Release._readJSON( "package.json" );
+	},
+
+	writePackage: function( json ) {
+		Release._writeJSON( "package.json", json );
+	},
+
+	_versionJSON: function( fileName, version ) {
+		if ( !fs.existsSync( Release.dir.repo + "/" + fileName ) ) {
+			return;
+		}
+		console.log( "Updating " + fileName + "..." );
+		var json = Release._readJSON( fileName );
+		json.version = version;
+		Release._writeJSON( fileName, json );
+	},
+
+	_setVersion: function( version ) {
+		Release._jsonFiles.forEach(function( file ) {
+			Release._versionJSON( file, version );
+		});
 	},
 
 	_getVersions: function() {
@@ -122,28 +147,36 @@ Release.define({
 	},
 
 	_createReleaseBranch: function() {
-		var package;
+		var json;
 
 		console.log( "Creating " + "release".cyan + " branch..." );
 		Release.git( "checkout -b release", "Error creating release branch." );
 		console.log();
 
-		console.log( "Updating package.json..." );
-		package = Release.readPackage();
-		package.version = Release.newVersion;
-		package.author.url = package.author.url.replace( "master", Release.newVersion );
-		package.licenses.forEach(function( license ) {
+		Release._setVersion( Release.newVersion );
+
+		// Update package.json URLs
+		console.log( "Updating package.json URLs..." );
+		json = Release.readPackage();
+		json.author.url = json.author.url.replace( "master", Release.newVersion );
+		json.licenses.forEach(function( license ) {
 			license.url = license.url.replace( "master", Release.newVersion );
 		});
-		Release.writePackage( package );
+		Release.writePackage( json );
 
 		Release.generateArtifacts( Release._createTag );
 	},
 
 	_createTag: function( paths ) {
+		var jsonFiles = [];
+		Release._jsonFiles.forEach(function( name ) {
+			if ( fs.existsSync( name ) ) {
+				jsonFiles.push( name );
+			}
+		});
 
 		// Ensure that at least one file is in the array so that `git add` won't error
-		paths = paths.concat( "package.json" );
+		paths = paths.concat( jsonFiles );
 
 		console.log( "Committing release artifacts..." );
 		Release.git( "add -f " + paths.join( " " ), "Error adding release artifacts to git." );
@@ -167,16 +200,12 @@ Release.define({
 	},
 
 	_updateBranchVersion: function() {
-		var package;
-
 		console.log( "Checking out " + Release.branch.cyan + " branch..." );
 		Release.git( "checkout " + Release.branch,
 			"Error checking out " + Release.branch + " branch." );
 
-		console.log( "Updating package.json..." );
-		package = Release.readPackage();
-		package.version = Release.nextVersion;
-		Release.writePackage( package );
+		// Update all JSON versions
+		Release._setVersion( Release.nextVersion );
 
 		console.log( "Committing version update..." );
 		Release.git( "commit -am 'Updating the " + Release.branch +


### PR DESCRIPTION
Whenever a version number is changed, repo calls `Release._setVersions( version )`. No new public methods are added.

To add more json files to the verison update list, one could update the array at `Release._jsonFiles`.

Fixes gh-4
