### PR TITLE
Lib: Ensure that every task that relies on the CWD sets it first

### DIFF
--- a/lib/cdn.js
+++ b/lib/cdn.js
@@ -10,6 +10,7 @@ module.exports = function( Release ) {
 				remote = Release.isTest ? testRemote : realRemote;
 
 			console.log( "Cloning " + remote.cyan + "..." );
+			Release.chdir( Release.dir.base );
 			Release.git( "clone " + remote + " " + local, "Error cloning CDN repo." );
 			console.log();
 
@@ -33,11 +34,12 @@ module.exports = function( Release ) {
 				projectCdn = jqueryCdn + "/" + Release.project + "/" + Release.newVersion;
 			}
 
+			Release.chdir( Release.dir.base );
 			shell.mkdir( "-p", projectCdn );
 			shell.cp( "-r", releaseCdn + "/*", projectCdn );
 
 			console.log( "Adding files..." );
-			process.chdir( projectCdn );
+			Release.chdir( projectCdn );
 			Release.git( "add ." , "Error adding files." );
 			Release.git( "commit -m '" + commitMessage + "'" , "Error commiting files." );
 			Release.git( "push", "Error pushing to CDN." );

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -26,6 +26,7 @@ Release.define({
 				"https://github.com/jquery/" + Release.project + "/issue/";
 
 		console.log( "Adding commits..." );
+		Release.chdir( Release.dir.repo );
 		commits = Release.gitLog( fullFormat );
 
 		console.log( "Adding links to tickets..." );

--- a/lib/contributors.js
+++ b/lib/contributors.js
@@ -16,6 +16,7 @@ Release.define({
 			contributorsPath = Release.dir.base + "/contributors.txt";
 
 		console.log( "Adding committers and authors..." );
+		Release.chdir( Release.dir.repo );
 		contributors = Release.gitLog( "%aN%n%cN" );
 
 		console.log( "Adding reporters and commenters from issues..." );

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -5,9 +5,10 @@ module.exports = function( Release ) {
 Release.define({
 	_jsonFiles: [ "package.json", "bower.json" ],
 	_cloneRepo: function() {
+		Release.chdir( Release.dir.base );
 		console.log( "Cloning " + Release.remote.cyan + "..." );
 		Release.git( "clone " + Release.remote + " " + Release.dir.repo, "Error cloning repo." );
-		process.chdir( Release.dir.repo );
+		Release.chdir( Release.dir.repo );
 
 		console.log( "Checking out " + Release.branch.cyan + " branch..." );
 		Release.git( "checkout " + Release.branch, "Error checking out branch." );
@@ -52,6 +53,7 @@ Release.define({
 				.split( /\r?\n/ )
 				.pop();
 
+		Release.chdir( Release.dir.repo );
 		result = Release.exec( "grunt authors", { silent: true } );
 		if ( result.code !== 0 ) {
 			Release.abort( "Error getting list of authors." );
@@ -149,6 +151,7 @@ Release.define({
 	_createReleaseBranch: function() {
 		var json;
 
+		Release.chdir( Release.dir.repo );
 		console.log( "Creating " + "release".cyan + " branch..." );
 		Release.git( "checkout -b release", "Error creating release branch." );
 		console.log();
@@ -178,6 +181,7 @@ Release.define({
 		// Ensure that at least one file is in the array so that `git add` won't error
 		paths = paths.concat( jsonFiles );
 
+		Release.chdir( Release.dir.repo );
 		console.log( "Committing release artifacts..." );
 		Release.git( "add -f " + paths.join( " " ), "Error adding release artifacts to git." );
 		Release.git( "commit -m 'Tagging the " + Release.newVersion + " release.'",
@@ -195,11 +199,13 @@ Release.define({
 	},
 
 	_pushRelease: function() {
+		Release.chdir( Release.dir.repo );
 		console.log( "Pushing release to git repo..." );
 		Release.git( "push --tags", "Error pushing tags to git repo." );
 	},
 
 	_updateBranchVersion: function() {
+		Release.chdir( Release.dir.repo );
 		console.log( "Checking out " + Release.branch.cyan + " branch..." );
 		Release.git( "checkout " + Release.branch,
 			"Error checking out " + Release.branch + " branch." );
@@ -214,6 +220,7 @@ Release.define({
 	},
 
 	_pushBranch: function() {
+		Release.chdir( Release.dir.repo );
 		console.log( "Pushing " + Release.branch.cyan + " to GitHub..." );
 		Release.git( "push", "Error pushing to GitHub." );
 	}

--- a/lib/util.js
+++ b/lib/util.js
@@ -7,6 +7,11 @@ module.exports = function( Release ) {
 Release.define({
 	exec: shell.exec,
 
+	chdir: function( directory ) {
+		console.log( "Changing working directory to " + directory.cyan + "." );
+		process.chdir( directory );
+	},
+
 	abort: function( msg ) {
 		console.log( msg.red );
 		console.log( "Aborting.".red );


### PR DESCRIPTION
Before, tasks implicitly relied on the CWD being correct. This actually
broke the _pushBranch task, which assumed to run in the repo directory.
Since the CDN related tasks change the CWD, that wasn't correct anymore.

In the future, all tasks that depend on the correct CWD need to
expliclty set it first.

Fixes #14
