### PR TITLE
Trac: Use normalized bugs URL from package

### DIFF
--- a/lib/trac.js
+++ b/lib/trac.js
@@ -1,9 +1,19 @@
 module.exports = function( Release ) {
 
 Release.define({
-	trac: function( path ) {
-		var tracUrl = "http://bugs." + Release.project + ".com";
+	_tracUrl: function() {
+		var bugs = Release.readPackage().bugs;
 
+		// Unwrap
+		if ( bugs.url ) {
+			bugs = bugs.url;
+		}
+
+		// Strip trailing slash
+		return bugs.replace( /\/$/, "" );
+	},
+	trac: function( path ) {
+		var tracUrl = Release._tracUrl();
 		return Release.exec({
 			command: "curl -s '" + tracUrl + path + "&format=tab'",
 			silent: true


### PR DESCRIPTION
Without this, the trac URL for jQuery UI ends up as "http://bugs.jquery-ui.com" (note the dash). This is another case where `Release.project` turns out to be invalid (didn't match npm package for QUnit, undefined/empty on Windows) - can we just remove it entirely?

I'm replacing the slash at the end since the `path` starts with a slash. In jQuery UI's package.json, the bugs URL ends with a slash, in jQuery Core it doesn't.
