### PR TITLE
NPM: Add npmTags() to provide full control over which tags are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ the shell, the commit log, and the issue list.
 If using Trac, return a different milestone to be used in the queries to
 generate a changelog and list of contributors. Defaults to `newVersion`.
 
+#### npmTags()
+
+An array of tags to apply to the npm release. Every release must contain at least
+one tag.
+
 #### issueTracker
 
 Which type of issue tracker is being used for the project. Must be either

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -38,6 +38,16 @@ module.exports = function( Release ) {
 			}
 		},
 
+		npmTags: function() {
+			var tags = [ "beta" ];
+
+			if ( !Release.preRelease ) {
+				tags.push( "latest" );
+			}
+
+			return tags;
+		},
+
 		_publishNpm: function() {
 			if ( !Release.npmPublish ) {
 				return;
@@ -45,20 +55,29 @@ module.exports = function( Release ) {
 
 			Release.chdir( Release.dir.repo );
 
-			var npmCommand = "npm publish";
-
-			if ( Release.preRelease ) {
-				npmCommand += " --tag beta";
-			}
+			var name = Release.readPackage().name,
+				npmTags = Release.npmTags(),
+				npmCommand = "npm publish --tag " + npmTags.pop();
 
 			if ( Release.isTest ) {
-				console.log( "Actual release would now publish to npm" );
-				console.log( "Would run: " + npmCommand.cyan );
-				return;
+				console.log( "Actual release would now publish to npm using:" );
+			} else {
+				console.log( "Publishing to npm, running:" );
 			}
 
-			console.log( "Publishing to npm, running " + npmCommand.cyan );
-			Release.exec( npmCommand );
+			console.log( "  " + npmCommand.cyan );
+			if ( !Release.isTest ) {
+				Release.exec( npmCommand );
+			}
+
+			while ( npmTags.length ) {
+				npmCommand = "npm tag " + name + "@" + Release.newVersion + " " + npmTags.pop();
+				console.log( "  " + npmCommand.cyan );
+				if ( !Release.isTest ) {
+					Release.exec( npmCommand );
+				}
+			}
+
 			console.log();
 		}
 	});


### PR DESCRIPTION
Fixes gh-29
Fixes gh-30

I'd like to have @jquery/core verify that this addresses their needs for handling 1.x/2.x simultaneous releases by overriding `npmTags()` on the 1.x-master branch.
