### PR TITLE
Util: Print a stacktrace when aborting

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -30,8 +30,11 @@ Release.define({
 	},
 
 	abort: function( msg ) {
+		var error = new Error();
+		Error.captureStackTrace( error );
 		console.log( msg.red );
 		console.log( "Aborting.".red );
+		console.log( error.stack );
 		process.exit( 1 );
 	},
 


### PR DESCRIPTION
Makes debugging easier, since the function causing the abort will be much easier to find. In more complicated cases, knowing the full call stack should help a lot.

`Error.captureStackTrace` is probably v8-only, but that's fine.
