### PR TITLE
Git: Log command when gitLog fails, improves debugging

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -2,11 +2,12 @@ module.exports = function( Release ) {
 
 Release.define({
 	gitLog: function( format ) {
-		var result = Release.exec({
-			command: "git log " + Release.prevVersion + ".." + Release.newVersion + " " +
+		var command = "git log " + Release.prevVersion + ".." + Release.newVersion + " " +
 				"--format='" + format + "'",
-			silent: true
-		}, "Error getting git log." );
+			result = Release.exec({
+				command: command,
+				silent: true
+			}, "Error getting git log, command was: " + command );
 
 		result = result.split( /\r?\n/ );
 		if ( result[ result.length - 1 ] === "" ) {


### PR DESCRIPTION
Similar to #50, improving debugging when things go wrong. Without the command its hard to tell why it fails.
