### PR TITLE
All: Replace Release.project with more appropriate values

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -48,7 +48,6 @@ Release.define({
 		}
 
 		console.log();
-		console.log( "\tProject: " + Release.project );
 		console.log( "\tRelease type: " + (Release.preRelease ? "pre-release" : "stable") );
 		console.log( "\tRemote: " + Release.remote );
 		console.log( "\tBranch: " + Release.branch );
@@ -71,15 +70,8 @@ Release.define({
 			process.exit( 1 );
 		}
 
-		// URL
-		if ( /:\/\//.test( remote ) ) {
-			Release.project = remote.replace( /.+\/([^\/]+)\.git/, "$1" );
-
-		// filesystem or GitHub
-		} else {
-			Release.project = remote.split( "/" ).pop();
-
-			// If it's not a local path, it must be a GitHub repo
+		// If it's not a local path, it must be a GitHub repo
+		if ( !/:\/\//.test( remote ) ) {
 			if ( !fs.existsSync( remote ) ) {
 				Release.isTest = !/^jquery\//.test( remote );
 				remote = "git@github.com:" + remote + ".git";

--- a/lib/cdn.js
+++ b/lib/cdn.js
@@ -6,18 +6,19 @@ module.exports = function( Release ) {
 		testRemote = "git@github.com:jquery/fake-cdn.git";
 
 	function projectCdn() {
-		var jqueryCdn = Release._cloneCdnRepo() + "/cdn";
-		if ( Release.project === "jquery" ) {
+		var npmPackage = Release.readPackage().name,
+			jqueryCdn = Release._cloneCdnRepo() + "/cdn";
+		if ( npmPackage === "jquery" ) {
 			return jqueryCdn;
 		}
-		if ( Release.project === "qunit" ) {
+		if ( npmPackage === "qunitjs" ) {
 			return jqueryCdn + "/qunit";
 		}
-		if ( /^jquery-/.test( Release.project ) ) {
-			return jqueryCdn + "/" + Release.project.substring( 7 ) +
+		if ( /^jquery-/.test( npmPackage ) ) {
+			return jqueryCdn + "/" + npmPackage.substring( 7 ) +
 				"/" + Release.newVersion;
 		}
-		return jqueryCdn + "/" + Release.project + "/" + Release.newVersion;
+		return jqueryCdn + "/" + npmPackage + "/" + Release.newVersion;
 	}
 
 	Release.define({

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -23,11 +23,9 @@ Release.define({
 
 	_generateCommitChangelog: function() {
 		var commits,
-			commitRef = "[%h](http://github.com/jquery/" + Release.project + "/commit/%H)",
+			commitRef = "[%h](" + Release._repositoryUrl() + "/commit/%H)",
 			fullFormat = "* %s (TICKETREF, " + commitRef + ")",
-			ticketUrl = Release.issueTracker === "trac" ?
-				"http://bugs." + Release.project + ".com/ticket/" :
-				"https://github.com/jquery/" + Release.project + "/issue/";
+			ticketUrl = Release._ticketUrl();
 
 		console.log( "Adding commits..." );
 		Release.chdir( Release.dir.repo );

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -82,6 +82,40 @@ Release.define({
 
 	checkRepoState: function() {},
 
+	// Unwrapped URL field from package.json, no trailing slash
+	_packageUrl: function( field ) {
+		var result = Release.readPackage()[ field ];
+
+		// Make sure it exists
+		if ( !result ) {
+			Release.abort( "Failed to read '" + field + "' URL field from package.json" );
+		}
+
+		// Unwrap
+		if ( result.url ) {
+			result = result.url;
+		}
+
+		// Strip trailing slash
+		return result.replace( /\/$/, "" );
+	},
+
+	_ticketUrl: function() {
+		return Release._packageUrl( "bugs" ) + ( Release.issueTracker === "trac" ?
+
+			// Trac bugs URL is just the host
+			"/ticket/" :
+
+			// GitHub bugs URL is host/user/repo/issues
+			"/" );
+	},
+
+	_repositoryUrl: function() {
+		return Release._packageUrl( "repository" )
+			.replace( /^git/, "https" )
+			.replace( /\.git$/, "" );
+	},
+
 	_readJSON: function( fileName ) {
 		var json = fs.readFileSync( Release.dir.repo + "/" + fileName, "utf8" );
 		Release.packageIndentation = json.match( /\n([\t\s]+)/ )[ 1 ];

--- a/lib/trac.js
+++ b/lib/trac.js
@@ -1,19 +1,8 @@
 module.exports = function( Release ) {
 
 Release.define({
-	_tracUrl: function() {
-		var bugs = Release.readPackage().bugs;
-
-		// Unwrap
-		if ( bugs.url ) {
-			bugs = bugs.url;
-		}
-
-		// Strip trailing slash
-		return bugs.replace( /\/$/, "" );
-	},
 	trac: function( path ) {
-		var tracUrl = Release._tracUrl();
+		var tracUrl = Release._packageUrl( "bugs" );
 		return Release.exec({
 			command: "curl -s '" + tracUrl + path + "&format=tab'",
 			silent: true


### PR DESCRIPTION
Use package name for CDN. Use bugs and repository fields for changelog.
Adds a _packageUrl method that the Trac module can also use.

Fixes gh-49
Closes gh-52
#50 and #51 were side effects while working on this. I actually missed the change from #50 a few times, since I put that in a separate branch.

Tested this against fake-project, jquery, jquery-ui, jquery-mobile and qunit. Since the changelog generation is barely working, I specifically check the return value of `_ticketUrl` and `_repositoryUrl` for each.
