### PR TITLE
Utils: Make Release.walk public

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,16 @@ Gets the contents of `package.json` as an object.
 
 Saves `package` to `package.json`, preserving indentation style.
 
+#### walk( methods, done )
+
+Executes the array of `methods` (minimum one element) step by step. For any
+given method, if that method accepts arguments (`method.length > 0`), it will
+pass a callback that the method needs to execute when done, making the method
+call async. Otherwise the method is assumed to be sync and the next method runs
+immediately.
+
+Once all methods are executed, the `done` callback is executed.
+
 ### Other Properties
 
 #### isTest

--- a/lib/util.js
+++ b/lib/util.js
@@ -53,7 +53,7 @@ Release.define({
 		};
 	},
 
-	_walk: function( methods, fn ) {
+	walk: function( methods, fn ) {
 		var method = methods.shift();
 
 		function next() {
@@ -61,7 +61,7 @@ Release.define({
 				return fn();
 			}
 
-			Release._walk( methods, fn );
+			Release.walk( methods, fn );
 		}
 
 		if ( !method.length ) {

--- a/release.js
+++ b/release.js
@@ -45,7 +45,7 @@ commonTasks = [
 	function( fn ) {
 		if ( Release.cdnPublish ) {
 			Release._section( "publishing to jQuery CDN" )();
-			Release._walk([
+			Release.walk([
 				Release._copyCdnArtifacts,
 				Release.confirmReview,
 				Release._pushToCdn
@@ -80,10 +80,10 @@ stableTasks = [
 	Release._gatherContributors
 ];
 
-Release._walk( commonTasks, function() {
+Release.walk( commonTasks, function() {
 	if ( Release.preRelease ) {
 		return Release.complete();
 	}
 
-	Release._walk( stableTasks, Release.complete );
+	Release.walk( stableTasks, Release.complete );
 });


### PR DESCRIPTION
This is used both by jQuery UI and jQuery Mobile release scripts. 
