### PR TITLE
Repo: Use valid semver for temp version

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -156,9 +156,9 @@ Release.define({
 			currentVersion = Release.readPackage().version;
 
 		console.log( "Validating current version..." );
-		if ( currentVersion.substr( -3, 3 ) !== "pre" ) {
+		if ( currentVersion.substr( -4, 4 ) !== "-pre" ) {
 			console.log( "The current version is " + currentVersion.red + "." );
-			Release.abort( "The version must be a pre version." );
+			Release.abort( "The version must be a pre version, e.g., 1.2.3-pre." );
 		}
 
 		if ( Release.preRelease ) {
@@ -167,7 +167,7 @@ Release.define({
 			// Note: prevVersion is not currently used for pre-releases.
 			Release.prevVersion = Release.nextVersion = currentVersion;
 		} else {
-			Release.newVersion = currentVersion.substr( 0, currentVersion.length - 3 );
+			Release.newVersion = currentVersion.substr( 0, currentVersion.length - 4 );
 			parts = Release.newVersion.split( "." );
 			major = parseInt( parts[ 0 ], 10 );
 			minor = parseInt( parts[ 1 ], 10 );
@@ -185,7 +185,7 @@ Release.define({
 				Release.prevVersion = [ major, minor, patch - 1 ].join( "." );
 			}
 
-			Release.nextVersion = [ major, minor, patch + 1 ].join( "." ) + "pre";
+			Release.nextVersion = [ major, minor, patch + 1 ].join( "." ) + "-pre";
 		}
 
 		console.log( "We are going from " + Release.prevVersion.cyan +


### PR DESCRIPTION
Using a valid semver between releases allows users to do an npm install against
a branch.

Ref jquery #15020
