### PR TITLE
Repo: allow synchronous or asynchronous Release.checkRepoState

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,13 @@ Release.define({
 
 ### Required/Recommended Configuration
 
-#### checkRepoState()
+#### checkRepoState( [ callback ] )
 
 Performs any project-specific checks to ensure the repository is in a good state to be released. For example, there is a built-in check to ensure that `AUTHORS.txt` is up-to-date.
 
 This method has no return value. If a project-specific check fails, the script should use `Release.abort()` to prevent the release from continuing.
+
+This method may be synchronous or asynchronous depending on the presence of `callback`. If present, the callback must be invoked.
 
 #### generateArtifacts( callback )
 

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -36,7 +36,7 @@ Release.define({
 		console.log();
 	},
 
-	_checkRepoState: function() {
+	_checkRepoState: function( fn ) {
 		if ( !Release.issueTracker ) {
 			Release.abort( "Missing required config: issueTracker." );
 		}
@@ -53,7 +53,8 @@ Release.define({
 		}
 
 		Release._checkAuthorsTxt();
-		Release.checkRepoState();
+
+		Release.walk( [ Release.checkRepoState ], fn );
 	},
 
 	_checkAuthorsTxt: function() {


### PR DESCRIPTION
We need this method to be asynchronous for [checking the Sizzle version in jQuery core](http://bugs.jquery.com/ticket/14915). This change is backwards-compatible.
