### PR TITLE
Changes for jQuery Core: read prevVersion from environment for major releases and add Release.dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ Executes the array of `methods` (minimum one element) step by step. For any give
 
 Once all methods are executed, the `done` callback is executed.
 
+#### dist( callback )
+
+This function is available in case the project requires more distribution than what is provided.
+It is called after building, but before publishing to npm.
+
 ### Other Properties
 
 #### isTest

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -172,8 +172,11 @@ Release.define({
 		patch = parseInt( parts[ 2 ], 10 );
 
 		if ( minor === 0 && patch === 0 ) {
-			Release.abort(
-				"This script is not smart enough to handle major release (eg. 2.0.0)." );
+			Release.prevVersion = process.env.PREV_VERSION;
+			if ( !Release.prevVersion ) {
+				Release.abort(
+					"For major releases, set PREV_VERSION in the environment." );
+			}
 		} else if ( patch === 0 ) {
 			Release.prevVersion = Release.exec(
 				"git for-each-ref --count=1 --sort=-authordate --format='%(refname:short)' " +

--- a/release.js
+++ b/release.js
@@ -61,6 +61,15 @@ commonTasks = [
 		}
 	},
 
+	function( fn ) {
+		if ( Release.dist ) {
+			Release._section( "additional custom distribution" );
+			Release.dist( fn );
+		} else {
+			fn();
+		}
+	},
+
 	function() {
 		if ( Release.npmPublish ) {
 			Release._section( "publishing to npm" )();


### PR DESCRIPTION
These are necessary updates that are required for the next jQuery Core release. There are only two changes:

1. Our next release is a major version release. Rather than reading the previous version in an automated way, it checks the environment for an explicit setting in order to continue.
2. Adds Release.dist, which is just an insertion point for all the extra distribution that Core will do from now on.

