### PR TITLE
CDN: push jquery-compat files to same folder as jquery

### DIFF
--- a/lib/cdn.js
+++ b/lib/cdn.js
@@ -8,7 +8,7 @@ module.exports = function( Release ) {
 	function projectCdn() {
 		var npmPackage = Release.readPackage().name,
 			jqueryCdn = Release._cloneCdnRepo() + "/cdn";
-		if ( npmPackage === "jquery" ) {
+		if ( npmPackage === "jquery" || npmPackage === "jquery-compat" ) {
 			return jqueryCdn;
 		}
 		if ( npmPackage === "qunitjs" ) {


### PR DESCRIPTION
I assume these will be available top-level. For instance, "http://code.jquery.com/jquery-compat-3.0.0.js".