### PR TITLE
CDN: Allow directory configuration via cdnPublish

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The version that will be set in `package.json` after the release.
 
 #### cdnPublish
 
-Set to `false` to prevent publishing to the jQuery CDN. Defaults to `true`.
+Which directory contains files to publish to the jQuery CDN. Set to `false` to prevent publishing to the jQuery CDN. Defaults to `"dist/cdn"`.
 
 #### npmPublish
 

--- a/lib/cdn.js
+++ b/lib/cdn.js
@@ -22,7 +22,7 @@ module.exports = function( Release ) {
 	}
 
 	Release.define({
-		cdnPublish: true,
+		cdnPublish: "dist/cdn",
 		_cloneCdnRepo: function() {
 			var local = Release.dir.base + "/codeorigin.jquery.com",
 				remote = Release.isTest ? testRemote : realRemote;
@@ -42,7 +42,7 @@ module.exports = function( Release ) {
 		_copyCdnArtifacts: function() {
 			var npmPackage = Release.readPackage().name,
 				targetCdn = projectCdn(),
-				releaseCdn = Release.dir.repo + "/dist/cdn",
+				releaseCdn = Release.dir.repo + "/" + Release.cdnPublish,
 				commitMessage = npmPackage + ": Added version " + Release.newVersion;
 
 			Release.chdir( Release.dir.base );


### PR DESCRIPTION
I'm working on the PEP release script and since our output is very simple (monolith + min), it's very convenient to just have `generateArtifacts()` run `Release.exec( "grunt" )` which generates those files in the `dist/` directory and then set `cdnPublish: "dist"` in the release config.

Since all existing projects should either be leaving the default value (previously `true`) to publish to the CDN, or setting to `false` to disable publishing to the CDN, this should be backward compatible.