### PR TITLE
GitHub: drop version labels when generating changelog

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -18,8 +18,12 @@ Release.define({
 				Release.abort( "Error getting milestones.", error );
 			}
 
+			var version = Release.preRelease ?
+				/^\d+\.\d+\.\d+/.exec( Release.newVersion )[ 0 ] :
+				Release.newVersion;
+
 			var milestone = milestones.filter(function( milestone ) {
-				return milestone.title === Release.newVersion;
+				return milestone.title === version;
 			})[ 0 ];
 
 			if ( !milestone ) {


### PR DESCRIPTION
I made this change to do the core release.

Fixes gh-82