### PR TITLE
Repo: check for licenses before looping over them

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -210,9 +210,11 @@ Release.define({
 		console.log( "Updating package.json URLs..." );
 		json = Release.readPackage();
 		json.author.url = json.author.url.replace( "master", Release.newVersion );
-		json.licenses.forEach(function( license ) {
-			license.url = license.url.replace( "master", Release.newVersion );
-		});
+		if ( json.licenses ) {
+			json.licenses.forEach(function( license ) {
+				license.url = license.url.replace( "master", Release.newVersion );
+			});
+		}
 		Release.writePackage( json );
 
 		Release.generateArtifacts(function( paths ) {


### PR DESCRIPTION
I had to make this change to do the core release.

Fixes gh-83