### PR TITLE
npm: Replace deprecated `tag` method with `dist-tag`

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -84,7 +84,7 @@ module.exports = function( Release ) {
 			}
 
 			while ( npmTags.length ) {
-				npmCommand = "npm tag " + name + "@" + Release.newVersion + " " + npmTags.pop();
+				npmCommand = "npm dist-tag add " + name + "@" + Release.newVersion + " " + npmTags.pop();
 				console.log( "  " + chalk.cyan( npmCommand ) );
 				if ( !Release.isTest ) {
 					Release.exec( npmCommand );


### PR DESCRIPTION
This is untested, but seemed straight-forward.

See https://docs.npmjs.com/cli/tag