### PR TITLE
repo: Install npm dependencies with the --no-save flag

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -19,7 +19,7 @@ Release.define({
 		console.log();
 
 		console.log( "Installing dependencies..." );
-		Release.exec( "npm install -q", "Error installing dependencies." );
+		Release.exec( "npm install --no-save", "Error installing dependencies." );
 		console.log();
 
 		projectRelease = require( Release.dir.repo + "/build/release" );
@@ -27,7 +27,7 @@ Release.define({
 		if ( projectRelease.dependencies ) {
 			console.log( "Installing release dependencies..." );
 			releaseDependencies = projectRelease.dependencies.join( " " );
-			Release.exec( "npm install -q " + releaseDependencies,
+			Release.exec( "npm install --no-save " + releaseDependencies,
 				"Error installing release dependencies." );
 			console.log();
 		}


### PR DESCRIPTION
This fixes https://github.com/jquery/jquery/issues/3947

- Also, I'm not sure `-q` does anything anymore. It's not documented in the [npm install docs](https://docs.npmjs.com/cli/install).