### PR TITLE
Build: Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/grunt
 node_modules/grunt-contrib-jshint
 test-*.sh
+package-lock.json


### PR DESCRIPTION
The same was previously done for jQuery Core.