### PR TITLE
GitHub: Fix repo detecting regexp

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -6,7 +6,7 @@ module.exports = function( Release ) {
 Release.define({
 	_githubApiPath: function( path ) {
 		var repoUrl = Release._packageUrl( "bugs" );
-		var repo = repoUrl.match( /github\.com\/(\w+\/\w+)/ )[ 1 ];
+		var repo = repoUrl.match( /github\.com\/([^/]+\/[^/]+)/ )[ 1 ];
 		return "/repos/" + repo + "/" + path;
 	},
 


### PR DESCRIPTION
The regular expression detecting the repository account+name didn't allow
accounts & repo names containing dashes because of matching both those parts
against the /\w+/ regexp. It was updated to match everything except the slash.

This made the release script fail for [jQuery Color](https://github.com/jquery/jquery-color).