### PR TITLE
Build: Use `npm ci` to install dependecies from package-json.lock

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -19,7 +19,7 @@ Release.define({
 		console.log();
 
 		console.log( "Installing dependencies..." );
-		Release.exec( "npm install --no-save", "Error installing dependencies." );
+		Release.exec( "npm ci", "Error installing dependencies." );
 		console.log();
 
 		projectRelease = require( Release.dir.repo + "/build/release" );


### PR DESCRIPTION
Closes https://github.com/jquery/jquery-release/issues/99

Wasnt able to verify the change right now.

We cannot use „npm ci“ to Install release dependencies because its designed to only do its magic for a whole project at once... no documented additional arguments