### PR TITLE
Build:util: await methods passed to Release.walk, test on Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "10"
+  - "12"

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,7 +58,7 @@ Release.define( {
 		};
 	},
 
-	walk: function( methods, fn ) {
+	walk: async function( methods, fn ) {
 		var method = methods.shift();
 
 		function next() {
@@ -70,10 +70,10 @@ Release.define( {
 		}
 
 		if ( !method.length ) {
-			method();
+			await method();
 			next();
 		} else {
-			method( next );
+			await method( next );
 		}
 	}
 } );

--- a/release.js
+++ b/release.js
@@ -2,6 +2,12 @@
 
 "use strict";
 
+// Stop the release process if any of the asynchronous operations fails.
+process.on( "unhandledRejection", reason => {
+	console.error( "Unhandled rejection:", reason );
+	throw reason;
+} );
+
 var commonTasks, stableTasks,
 	fs = require( "fs" ),
 	Release = {


### PR DESCRIPTION
Changes:
1. Test on Node.js 12 instead of 10
2. Make `Release.walk` an async function, `await` each provided method. This
makes it possible to easier integrate with asynchronous flows in various steps.