### PR TITLE
npm: Ask for a one-time password for `npm dist-tag add` as well

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -98,7 +98,13 @@ module.exports = function( Release ) {
 			Release.exec( npmPublish );
 
 			while ( npmTags.length ) {
-				npmPublish = "npm dist-tag add " + newVersion + " " + npmTags.pop();
+
+				// Ask for OTP before adding each tag as the code may get invalid
+				// if the process takes too long.
+				otp = await Release._getNpmOtp();
+				npmPublish = `npm dist-tag add ${ newVersion } ${ npmTags.pop() } ${
+					otp ? `--otp ${ otp }` : ""
+				}`;
 				console.log( "  " + chalk.cyan( npmPublish ) );
 				if ( !Release.isTest ) {
 					Release.exec( npmPublish );


### PR DESCRIPTION
This fixes the issue that broke the Sizzle release process for me. Hopefully I didn't miss anything this time. ;)