### PR TITLE
Repo: Update the version in package-lock.json as well

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -6,7 +6,7 @@ var fs = require( "fs" ),
 module.exports = function( Release ) {
 
 Release.define( {
-	_jsonFiles: [ "package.json", "bower.json" ],
+	_jsonFiles: [ "package.json", "package-lock.json", "bower.json" ],
 	_cloneRepo: function() {
 		var projectRelease, releaseDependencies;
 
@@ -270,6 +270,7 @@ Release.define( {
 
 		// Update only canonical version
 		Release._versionJSON( "package.json", Release.nextVersion );
+		Release._versionJSON( "package-lock.json", Release.nextVersion );
 
 		console.log( "Committing version update..." );
 		Release.exec( "git commit -am \"Build: Updating the " + Release.branch +


### PR DESCRIPTION
Not doing that caused Sizzle to have an outdated `package-lock.json` file in [its `2.3.5` release](https://github.com/jquery/sizzle/commit/f23fb1641c95a0836e42f2cd5694f1544e521196) that [I had to fix afterwards](https://github.com/jquery/sizzle/commit/f441747f8081f997ed72067cd2c94dc167844a2b).